### PR TITLE
Remove non-existent BLE exports

### DIFF
--- a/services/index.ts
+++ b/services/index.ts
@@ -1,10 +1,8 @@
 // src/services/index.ts
-export { BLEManager, getBLEManager, destroyBLEManager } from './BLEManager';
-export type { 
-    BLEOptions,
-    ConnectionState,
-    DeviceConnectionMetrics,
-    FileInfo,
-    TransferProgress,
-    BLEManagerEvents 
-} from './BLETypes';
+export { BLECommsManager } from './BLECommsManager';
+export { BLEConnectionManager, sharedBLEConnectionManager } from './BLEConnectionManager';
+export { WifiRestApiClient } from './WifiRestApiClient';
+export { GrayscaleConverter } from './GrayscaleConverter';
+export { ImageProcessor } from './imageProcessor';
+export { EnhancedLogger } from './enhancedLogger';
+export { logger } from './logger';


### PR DESCRIPTION
## Summary
- drop BLEManager exports from services barrel

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418131b020832fad932ad9d9c599ff