### PR TITLE
Fix GrayscaleConverter import

### DIFF
--- a/services/GrayscaleConverter.ts
+++ b/services/GrayscaleConverter.ts
@@ -3,7 +3,7 @@
 import { manipulateAsync, SaveFormat } from 'expo-image-manipulator';
 import * as FileSystem from 'expo-file-system';
 import { logger } from './logger';
-import { ProcessedImage, GrayscaleResult } from './ImageProcessor';
+import { ProcessedImage, GrayscaleResult } from './imageProcessor';
 import { Buffer } from 'buffer';
 import { decode as decodePNG } from 'fast-png';
 


### PR DESCRIPTION
## Summary
- adjust imageProcessor import path to match filename

## Testing
- `npx tsc --noEmit` *(fails: expo tsconfig not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420d881878832f8822fba8572c4fd8