### PR TITLE
Fix ImageDetailModal import paths

### DIFF
--- a/components/ImageDetailModal.tsx
+++ b/components/ImageDetailModal.tsx
@@ -1,16 +1,17 @@
 // components/ImageDetailModal.tsx
 import React from 'react';
-import { 
-  View, 
-  StyleSheet, 
-  Modal, 
-  Text, 
-  ScrollView, 
+import {
+  View,
+  StyleSheet,
+  Modal,
+  Text,
+  ScrollView,
   TouchableOpacity,
-  Dimensions
+  Dimensions,
+  Image
 } from 'react-native';
 import { IconButton, Button } from 'react-native-paper';
-import { ProcessedImage } from '../app/(tabs)/library';
+import { ProcessedImage } from '../services/imageProcessor';
 
 interface ImageDetailModalProps {
   image: ProcessedImage | null;


### PR DESCRIPTION
## Summary
- import `Image` properly in the image detail modal
- pull `ProcessedImage` type from `services/imageProcessor`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: File 'expo/tsconfig.base' not found)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887de227cdc832fa141ef5bafc57605