### PR TITLE
Fix logger import casing

### DIFF
--- a/services/WifiRestApiClient.ts
+++ b/services/WifiRestApiClient.ts
@@ -6,7 +6,7 @@
  * and checking storage space.
  */
 
-import { EnhancedLogger } from './EnhancedLogger';
+import { EnhancedLogger } from './enhancedLogger';
 
 // Interface for representing file information from the device
 export interface FileInfo {


### PR DESCRIPTION
## Summary
- align `WifiRestApiClient` logger import casing with other modules

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887df7871f4832fa8baf9ef169cb2bc