### PR TITLE
Fix theme hook import

### DIFF
--- a/components/ThemedText.tsx
+++ b/components/ThemedText.tsx
@@ -2,7 +2,7 @@
 
 import { Text, type TextProps, StyleSheet } from 'react-native';
 
-import { useThemeColor } from '@/hooks/useThemeColor';
+import useThemeColor from '@/hooks/useThemeColor';
 
 export type ThemedTextProps = TextProps & {
   lightColor?: string;

--- a/components/ThemedView.tsx
+++ b/components/ThemedView.tsx
@@ -2,7 +2,7 @@
 
 import { View, type ViewProps } from 'react-native';
 
-import { useThemeColor } from '@/hooks/useThemeColor';
+import useThemeColor from '@/hooks/useThemeColor';
 
 export type ThemedViewProps = ViewProps & {
   lightColor?: string;


### PR DESCRIPTION
## Summary
- use default import for `useThemeColor` in `ThemedText` and `ThemedView`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e9b53980832fb61455d5b4ca349b